### PR TITLE
fix: Re-attempt calendar authorization when the user changes privacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@ Generate monthly durations for similarly named calendar events.
 
 ## Development
 
+### Builds
+
 Overview follows the version numbering, build and signing conventions for InSeven apps. Further details can be found [here](https://github.com/inseven/build-documentation).
+
+Release builds are created on GitHub Actions using 'build.sh' in the 'scripts' directory. This script is primarily focused on setting up the environment for testing and signing. Local builds can be performed using the  Xcode project found in the 'macOS' directory.
+
+### Tests
+
+It's helpful to be able to manually walk through the full Calendar authorisation flows before release. This authorisation can be reset using the following command, which should allow for testing the first-run experience:
+
+```bash
+tccutil reset Calendar uk.co.jbmorley.apps.overview
+```
 
 ## Licensing
 


### PR DESCRIPTION
This change ensures we re-attempt authorization when the application enters the foreground, ensuring we respond to changes made through System Settings (which we prompt the user to do).

This introduces a number of lifecycle changes and, as a result, also ensures that we re-fetch the active calendars and events whenever the app is newly authorized or calendar events change.