### PR TITLE
fix: Ensure all day events show the correct duration

### DIFF
--- a/macos/Overview/Model/Event.swift
+++ b/macos/Overview/Model/Event.swift
@@ -24,14 +24,29 @@ protocol Event {
 
     var startDate: Date! { get set }
     var endDate: Date! { get set }
+    var isAllDay: Bool { get set }
 
 }
 
 extension Event {
 
     func duration(calendar: Calendar, bounds: DateInterval) -> DateComponents {
+
+        // Unfortunately it seems that somewhere along the line, EventKit has started treating all day events and
+        // timed events differently--timed events return an endDate that is exclusive, and all day events have an
+        // endDate which is inclusive. Given this, we have to check to see if it's an all day event and adjust its end
+        // date by 1 second.
+        let endDate: Date
+        if isAllDay {
+            endDate = self.endDate + 1
+        } else {
+            endDate = self.endDate
+        }
+
+        // Determine the bounded start and end dates.
         let start = max(bounds.start, startDate)
         let end = min(bounds.end, endDate)
+
         return calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: start, to: end)
     }
 


### PR DESCRIPTION
It looks like Apple changed the end dates returned for [just] all day events. This change accounts for that.