### PR TITLE
ci: Don't validate builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,14 +153,6 @@ PKG_PATH="$BUILD_DIRECTORY/Overview.pkg"
 mkdir -p ~/.appstoreconnect/private_keys/
 echo -n "$APPLE_API_KEY_BASE64" | base64 --decode -o ~/".appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
 
-# Validate the macOS build.
-xcrun altool --validate-app \
-    -f "${PKG_PATH}" \
-    --apiKey "$APPLE_API_KEY_ID" \
-    --apiIssuer "$APPLE_API_KEY_ISSUER_ID" \
-    --output-format json \
-    --type macos
-
 # Archive the build directory.
 ZIP_BASENAME="build-${VERSION_NUMBER}-${BUILD_NUMBER}.zip"
 ZIP_PATH="${BUILD_DIRECTORY}/${ZIP_BASENAME}"


### PR DESCRIPTION
It looks like the validate step is less permissive than the App Store upload when it comes to checking versions for closed release trains. Testing this theory by removing the validate step.